### PR TITLE
nrpe on Debian uses different process_group

### DIFF
--- a/data/nrpe/osfamily/Debian.yaml
+++ b/data/nrpe/osfamily/Debian.yaml
@@ -5,5 +5,6 @@ nrpe::settings:
   config_dir_path: '/etc/nagios/nrpe.d'
   conf_dir_path: '/etc/nagios/nrpe.d'
   process_user: 'nagios'
+  process_group: 'nagios'
   pid_file_path: '/var/run/nagios/nrpe.pid'
   init_file_path: '/etc/default/nagios-nrpe-server'


### PR DESCRIPTION
Nrpe on Debian uses nagios as a group.